### PR TITLE
fix: use own version of foreach for non es5 compliant browsers (ie8)

### DIFF
--- a/packages/obsolete-web/src/lib/comparator.js
+++ b/packages/obsolete-web/src/lib/comparator.js
@@ -1,3 +1,5 @@
+import { forEach } from './mini-built-ins';
+
 /**
  * Validate if a string is semantic version.
  *
@@ -24,7 +26,7 @@ function compareVersion(version, comparedVersion) {
   const rVersion = /\d+/g;
   const rComparedVersion = /\d+/g;
 
-  [version, comparedVersion].forEach(version => {
+  forEach([version, comparedVersion], version => {
     validateSemantic(version);
   });
 


### PR DESCRIPTION
Currently the comparator uses the ES5 `Array.forEach` which seems to be the only ES5 feature that the `obsolete-web` package uses.
This fix allows the `obsolete-web` package to run in IE8 without shimming ES5.